### PR TITLE
Removed Filter should reappear without selection

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -92,10 +92,12 @@ export class DataSource extends DataSourceApi<MyQuery> {
   }
 
   async doRequest<T>(options: MyQuery): Promise<FetchResponse<ResponseData<T>>> {
+    const { selections, ...params } = options.params; // remove selections from params
+    // TODO: we should find a better place for selections!
     return this.cmkRequest<T>({
       method: options.data == null ? 'GET' : 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      url: buildUrlWithParams(`${this.instanceSettings.url}/cmk/check_mk/webapi.py`, { ...options.params }),
+      url: buildUrlWithParams(`${this.instanceSettings.url}/cmk/check_mk/webapi.py`, { ...params }),
       data: options.data,
     });
   }

--- a/src/components/combinedgraphs.tsx
+++ b/src/components/combinedgraphs.tsx
@@ -86,6 +86,9 @@ export const SelectFilters = (props: FilterEditorProps): null | JSX.Element => {
     if (query.context) {
       delete query.context[filtername];
     }
+    if (query.params.selections?.context) {
+      delete query.params.selections.context[filtername];
+    }
     onChange(query);
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,9 @@ export interface QueryParams {
   graphMode?: 'metric' | 'template';
   presentation?: Presentation;
   graph_name?: string;
+  selections?: {
+    context?: Record<string, unknown>;
+  };
   action?: 'get_graph' | 'get_combined_graph_identifications';
 }
 


### PR DESCRIPTION
* add host filter
* choose host "X"
* remove host filter
* add host filter

-> host "X" was selected, but graph did not reflect this

Now the selection of the host filter (and other filters) is empty when
readding them.