### PR TITLE
New e2e test to create and delete a cmk host

### DIFF
--- a/tests/cypress/e2e/helpers.ts
+++ b/tests/cypress/e2e/helpers.ts
@@ -24,3 +24,54 @@ export function createCmkAutomationUser(cmkUser: string, cmkPassword: string) {
     },
   });
 }
+
+export function createCmkHost(hostName: string) {
+  cy.request({
+    method: 'POST',
+    url: Cypress.env('cypressToCheckmkUrl') + '/check_mk/api/1.0/domain-types/host_config/collections/all',
+    auth: {
+      bearer: `${Cypress.env('cmkUsername')} ${Cypress.env('cmkPassword')}`,
+    },
+    headers: { accept: 'application/json' },
+    qs: { bake_agent: false },
+    body: {
+      folder: '/',
+      host_name: hostName,
+      attributes: {
+        ipaddress: '127.0.0.1',
+      },
+    },
+  });
+}
+
+export function deleteCmkHost(hostName: string) {
+  cy.request({
+    method: 'DELETE',
+    url: Cypress.env('cypressToCheckmkUrl') + '/check_mk/api/1.0/objects/host_config/' + hostName,
+    headers: { accept: 'application/json' },
+    auth: {
+      bearer: `${Cypress.env('cmkUsername')} ${Cypress.env('cmkPassword')}`,
+    },
+  });
+}
+
+export function activateCmkChanges(siteName: string) {
+  cy.request({
+    method: 'POST',
+    url:
+      Cypress.env('cypressToCheckmkUrl') +
+      '/check_mk/api/1.0/domain-types/activation_run/actions/activate-changes/invoke',
+    followRedirect: true,
+    headers: { content: 'application/json' },
+    auth: {
+      bearer: `${Cypress.env('cmkUsername')} ${Cypress.env('cmkPassword')}`,
+    },
+    body: {
+      redirect: false,
+      sites: [siteName],
+      force_foreign_changes: false,
+    },
+  }).then((response) => {
+    expect(response.status).is.equal(200);
+  });
+}

--- a/tests/cypress/e2e/spec.cy.ts
+++ b/tests/cypress/e2e/spec.cy.ts
@@ -1,8 +1,9 @@
-import { createCmkAutomationUser } from './helpers';
+import { createCmkAutomationUser, createCmkHost, deleteCmkHost, activateCmkChanges } from './helpers';
 
 describe('Source configuration', () => {
   const cmkUser = 'cmkuser';
   const cmkPassword = 'somepassword123457';
+  const hostName = 'localhost_' + Math.floor(Date.now() / 1000);
 
   it('configures the datasource correctly', () => {
     createCmkAutomationUser(cmkUser, cmkPassword);
@@ -22,5 +23,13 @@ describe('Source configuration', () => {
     cy.get('[aria-label="Data source settings page Save and Test button"]').click();
 
     cy.get('[data-testid="data-testid Alert success"]').should('be.visible');
+  });
+
+  it('create and delete host', () => {
+    createCmkHost(hostName);
+    activateCmkChanges('cmk');
+
+    deleteCmkHost(hostName);
+    activateCmkChanges('cmk');
   });
 });


### PR DESCRIPTION
A new e2e test is here introduced. Such test verifies the correct implementation of the 'helpers' functions to create and delete a cmk host and to apply changes, all via REST API requests.