### PR TITLE
ci: upload cypress artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,13 @@ jobs:
       - name: run the e2e tests
         run: docker-compose up --exit-code-from=cypress
         working-directory: tests/
+
+      - name: upload cypress artifacts
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cypress
+          retention-days: 1
+          path: |
+            tests/cypress/videos
+            tests/cypress/screenshots


### PR DESCRIPTION
should make it easier to debug those timeout issues we currently see.