### PR TITLE
Fix e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: plugin-build-result
+          path: dist
 
       - name: run the e2e tests
         run: docker-compose up --exit-code-from=cypress

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   grafana:
     image: grafana/grafana-oss:9.1.0-ubuntu
     volumes:
-      - ..:/var/lib/grafana/plugins/grafana-checkmk-datasource
+      - ../dist/:/var/lib/grafana/plugins/grafana-checkmk-datasource
     environment:
       GF_ANALYTICS_REPORTING_ENABLED: 'false'
       GF_ANALYTICS_CHECK_FOR_UPDATES: 'false'


### PR DESCRIPTION
It looks like we mounted the whole project into the grafana container, but we should just mount the dist folder. This should fix the following warning message seen for the grafana container:

  logger=plugin.loader
  t=2022-12-12T14:14:45.060474032Z
  level=warn
  msg="Plugin missing module.js"
  pluginID=tribe-29-checkmk-datasource
  warning="Missing module.js, If you loaded this plugin from git, make sure to compile it."
  path=/var/lib/grafana/plugins/grafana-checkmk-datasource/src/module.js