### PR TITLE
Split function for creating and deleting automation user

### DIFF
--- a/tests/cypress/e2e/helpers.ts
+++ b/tests/cypress/e2e/helpers.ts
@@ -1,13 +1,5 @@
 export function createCmkAutomationUser(cmkUser: string, cmkPassword: string) {
   cy.request({
-    method: 'DELETE',
-    url: Cypress.env('cypressToCheckmkUrl') + '/check_mk/api/1.0/objects/user_config/' + cmkUser,
-    auth: {
-      bearer: `${Cypress.env('cmkUsername')} ${Cypress.env('cmkPassword')}`,
-    },
-    failOnStatusCode: false,
-  });
-  cy.request({
     method: 'POST',
     url: Cypress.env('cypressToCheckmkUrl') + '/check_mk/api/1.0/domain-types/user_config/collections/all',
     auth: {
@@ -22,6 +14,17 @@ export function createCmkAutomationUser(cmkUser: string, cmkPassword: string) {
         secret: cmkPassword,
       },
     },
+  });
+}
+
+export function deleteCmkAutomationUser(cmkUser: string, cmkPassowrd: string, failOnStatusCode: boolean = true) {
+  cy.request({
+    method: 'DELETE',
+    url: Cypress.env('cypressToCheckmkUrl') + '/check_mk/api/1.0/objects/user_config/' + cmkUser,
+    auth: {
+      bearer: `${Cypress.env('cmkUsername')} ${Cypress.env('cmkPassword')}`,
+    },
+    failOnStatusCode: failOnStatusCode,
   });
 }
 

--- a/tests/cypress/e2e/spec.cy.ts
+++ b/tests/cypress/e2e/spec.cy.ts
@@ -1,15 +1,25 @@
 import { Method } from 'cypress/types/net-stubbing';
-import { activateCmkChanges, createCmkAutomationUser, createCmkHost, deleteCmkHost, recursiveType } from './helpers';
+import {
+  activateCmkChanges,
+  createCmkAutomationUser,
+  createCmkHost,
+  deleteCmkHost,
+  recursiveType,
+  deleteCmkAutomationUser,
+} from './helpers';
 
-describe('Source configuration', () => {
+describe('e2e tests', () => {
   const cmkUser = 'cmkuser';
   const cmkPassword = 'somepassword123457';
   const randID = Math.floor(Date.now() / 1000);
   const hostName = 'localhost_' + randID;
 
-  it('configures the datasource correctly', () => {
+  before(function () {
+    deleteCmkAutomationUser(cmkUser, cmkPassword, false); // clean-up possible existing user
     createCmkAutomationUser(cmkUser, cmkPassword);
+  });
 
+  it('configures the datasource correctly', () => {
     cy.visit('/');
     cy.get('input[name="user"]').type(Cypress.env('grafanaUsername'));
     cy.get('input[name="password"]').type(Cypress.env('grafanaPassword'));
@@ -74,5 +84,9 @@ describe('Source configuration', () => {
 
     deleteCmkHost(hostName);
     activateCmkChanges('cmk');
+  });
+
+  after(function () {
+    deleteCmkAutomationUser(cmkUser, cmkPassword);
   });
 });


### PR DESCRIPTION
The function to create and delete an automation user is here divided into two separate ones. In this way, we can properly clean-up the created user inside the test.