### PR TITLE
Clarify aggregation and presentation

### DIFF
--- a/src/RequestSpec.ts
+++ b/src/RequestSpec.ts
@@ -9,7 +9,7 @@ export interface RequestSpec {
   // my suggestion: entity_type and entity then it should be clear that they influence each other.
   graph_type: string;
 
-  aggregation: string;
+  aggregation: Aggregation;
 
   site: string | undefined;
 
@@ -32,15 +32,14 @@ export interface TagValue {
   operator?: string;
 }
 
-// TODO: is unused.
-export type Aggregation = 'lines' | 'sum' | 'average' | 'min' | 'max';
+export type Aggregation = 'off' | 'sum' | 'average' | 'minimum' | 'maximum';
 
 export type RequestSpecStringKeys = 'host_name' | 'site' | 'service' | 'graph' | 'graph_type' | 'aggregation';
 
 export type RequestSpecNegatableOptionKeys = 'host_name_regex' | 'service_regex' | 'host_in_group' | 'service_in_group';
 
 export const defaultRequestSpec: Partial<RequestSpec> = {
-  aggregation: 'lines',
+  aggregation: 'off',
   graph_type: 'template',
 };
 export type FilterEditorKeys =

--- a/src/RequestSpec.ts
+++ b/src/RequestSpec.ts
@@ -7,7 +7,7 @@ export interface RequestSpec {
   // TODO: we need to rename graph_type, as the graph_type differentiates between graph and metric.
   // TODO: we also need to rename graph, as this could contain a metric name.
   // my suggestion: entity_type and entity then it should be clear that they influence each other.
-  graph_type: string;
+  graph_type: GraphType;
 
   aggregation: Aggregation;
 
@@ -32,6 +32,8 @@ export interface TagValue {
   operator?: string;
 }
 
+export type GraphType = 'single_metric' | 'predefined_graph';
+
 export type Aggregation = 'off' | 'sum' | 'average' | 'minimum' | 'maximum';
 
 export type RequestSpecStringKeys = 'host_name' | 'site' | 'service' | 'graph' | 'graph_type' | 'aggregation';
@@ -40,7 +42,7 @@ export type RequestSpecNegatableOptionKeys = 'host_name_regex' | 'service_regex'
 
 export const defaultRequestSpec: Partial<RequestSpec> = {
   aggregation: 'off',
-  graph_type: 'template',
+  graph_type: 'predefined_graph',
 };
 export type FilterEditorKeys =
   | 'site'

--- a/src/backend/rest.ts
+++ b/src/backend/rest.ts
@@ -11,7 +11,7 @@ import {
   dateTime,
 } from '@grafana/data';
 import { BackendSrvRequest, FetchResponse, getBackendSrv } from '@grafana/runtime';
-import { Aggregation } from 'RequestSpec';
+import { Aggregation, GraphType } from 'RequestSpec';
 
 import { CmkQuery } from '../types';
 import { createCmkContext, updateQuery } from '../utils';
@@ -32,7 +32,7 @@ type RestApiGraphResponse = {
 };
 
 type CommonRequest = {
-  type: 'single_metric' | 'graph';
+  type: GraphType;
   metric_id?: string;
   graph_id?: string;
   time_range: {
@@ -136,20 +136,20 @@ export default class RestApiBackend implements Backend {
     // prepare data required by cre and cee
     if (
       query.requestSpec === undefined ||
-      (query.requestSpec.graph_type !== 'metric' && query.requestSpec.graph_type !== 'template') ||
+      (query.requestSpec.graph_type !== 'single_metric' && query.requestSpec.graph_type !== 'predefined_graph') ||
       query.requestSpec.graph === undefined
     ) {
       throw 'Query is missing required fields';
     }
 
     const commonRequest: CommonRequest = {
-      type: query.requestSpec.graph_type === 'metric' ? 'single_metric' : 'graph',
+      type: query.requestSpec.graph_type,
       time_range: {
         start: range.from.toISOString(),
         end: range.to.toISOString(),
       },
     };
-    if (query.requestSpec.graph_type === 'metric') {
+    if (commonRequest.type === 'single_metric') {
       commonRequest['metric_id'] = query.requestSpec.graph;
     } else {
       commonRequest['graph_id'] = query.requestSpec.graph;

--- a/src/backend/rest.ts
+++ b/src/backend/rest.ts
@@ -39,13 +39,11 @@ type CommonRequest = {
     end: string;
   };
 };
-type RestApiGetRequest =
-  | {
-      site?: string;
-      host_name: string;
-      service_description: string;
-    }
-  | CommonRequest;
+type RestApiGetRequest = {
+  site?: string;
+  host_name: string;
+  service_description: string;
+} & CommonRequest;
 
 export default class RestApiBackend implements Backend {
   datasource: DatasourceOptions;

--- a/src/backend/rest.ts
+++ b/src/backend/rest.ts
@@ -11,6 +11,7 @@ import {
   dateTime,
 } from '@grafana/data';
 import { BackendSrvRequest, FetchResponse, getBackendSrv } from '@grafana/runtime';
+import { Aggregation } from 'RequestSpec';
 
 import { CmkQuery } from '../types';
 import { createCmkContext, updateQuery } from '../utils';
@@ -43,6 +44,11 @@ type RestApiGetRequest = {
   site?: string;
   host_name: string;
   service_description: string;
+} & CommonRequest;
+
+type RestApiFilterRequest = {
+  aggregation?: Aggregation;
+  filter: unknown;
 } & CommonRequest;
 
 export default class RestApiBackend implements Backend {
@@ -176,13 +182,15 @@ export default class RestApiBackend implements Backend {
       });
     } else {
       // send request for cee
+      const request: RestApiFilterRequest = {
+        filter: createCmkContext(query.requestSpec),
+        aggregation: query.requestSpec.aggregation,
+        ...commonRequest,
+      };
       response = await this.api<RestApiGraphResponse>({
         url: '/domain-types/metric/actions/filter/invoke',
         method: 'POST',
-        data: {
-          filter: createCmkContext(query.requestSpec),
-          ...commonRequest,
-        },
+        data: request,
       });
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,5 +78,3 @@ export interface SecureJsonData {
 export interface ResponseDataAutocomplete {
   choices: Array<[string, string]>;
 }
-
-export type GraphKind = 'template' | 'metric';

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,10 @@ import { RequestSpec, defaultRequestSpec } from './RequestSpec';
 
 export type ContextHTTPVars = Record<string, string>;
 
+// TODO: should be moved to webapi types
 type Negative = undefined | 'on' | '';
 
+// TODO: should be moved to webapi types
 export interface Context {
   host?: {
     host: string;
@@ -32,10 +34,10 @@ export interface Context {
   };
 }
 
+// TODO: should be moved to webapi types
 export interface Params {
   graphMode: 'metric' | 'template';
   graph_name: string;
-  // TODO: duplicate with definition in autocomplete
   presentation: 'lines' | 'sum' | 'average' | 'min' | 'max';
   selections: unknown;
 }

--- a/src/ui/QueryEditor.tsx
+++ b/src/ui/QueryEditor.tsx
@@ -3,9 +3,9 @@ import { InlineFieldRow, VerticalGroup } from '@grafana/ui';
 import React from 'react';
 
 import { DataSource } from '../DataSource';
-import { Aggregation, RequestSpec } from '../RequestSpec';
-import { CmkQuery, DataSourceOptions, GraphKind, ResponseDataAutocomplete } from '../types';
-import { aggregationToPresentation, titleCase, updateQuery } from '../utils';
+import { Aggregation, GraphType, RequestSpec } from '../RequestSpec';
+import { CmkQuery, DataSourceOptions, ResponseDataAutocomplete } from '../types';
+import { aggregationToPresentation, updateQuery } from '../utils';
 import { createAutocompleteConfig } from './autocomplete';
 import {
   CheckMkSelect,
@@ -50,7 +50,7 @@ export const QueryEditor = (props: Props): JSX.Element => {
   updateQuery(query);
   const rs = query.requestSpec || {};
   const [qAggregation, setQAggregation] = React.useState(rs.aggregation || 'off');
-  const [qGraphType, setQGraphType] = React.useState(rs.graph_type || 'template');
+  const [qGraphType, setQGraphType] = React.useState(rs.graph_type || 'predefined_graph');
   const [qSite, setQSite] = React.useState(rs.site);
   const [qHost, setQHost] = React.useState({
     host_name: rs.host_name,
@@ -94,9 +94,9 @@ export const QueryEditor = (props: Props): JSX.Element => {
     { value: 'maximum', label: 'Maximum' },
   ];
 
-  const graphTypeCompleter = async (): Promise<Array<SelectableValue<GraphKind>>> => [
-    { value: 'template', label: 'Template' },
-    { value: 'metric', label: 'Single metric' },
+  const graphTypeCompleter = async (): Promise<Array<SelectableValue<GraphType>>> => [
+    { value: 'predefined_graph', label: 'Predefined graph' },
+    { value: 'single_metric', label: 'Single metric' },
   ];
 
   const siteAutocompleter = React.useCallback(
@@ -161,7 +161,7 @@ export const QueryEditor = (props: Props): JSX.Element => {
       let ident: string;
       let params = {};
       if (datasource.getEdition() === 'RAW') {
-        ident = qGraphType === 'metric' ? 'monitored_metrics' : 'available_graphs';
+        ident = qGraphType === 'single_metric' ? 'monitored_metrics' : 'available_graphs';
         params = { strict: 'with_source' };
         // 2.1.0 changed { strict: 'with_source' } to:
         // strict: true,
@@ -171,7 +171,7 @@ export const QueryEditor = (props: Props): JSX.Element => {
         ident = 'combined_graphs';
         params = {
           presentation: aggregationToPresentation(qAggregation), // TODO: not 100% sure if this is needed, but 2.0.1 does it that way
-          mode: qGraphType,
+          mode: qGraphType === 'single_metric' ? 'metric' : 'template',
           datasource: 'services',
           single_infos: ['host'],
         };
@@ -210,7 +210,7 @@ export const QueryEditor = (props: Props): JSX.Element => {
           autocompleter={graphTypeCompleter}
         />
         <CheckMkSelect
-          label={titleCase(qGraphType)}
+          label={qGraphType === 'predefined_graph' ? 'Predefined graph' : 'Single metric'}
           value={qGraph}
           onChange={setQGraph}
           autocompleter={graphAutocompleter}
@@ -302,7 +302,7 @@ export const QueryEditor = (props: Props): JSX.Element => {
           autocompleter={graphTypeCompleter}
         />
         <CheckMkSelect
-          label={titleCase(qGraphType)}
+          label={qGraphType === 'predefined_graph' ? 'Predefined graph' : 'Single metric'}
           value={qGraph}
           onChange={setQGraph}
           autocompleter={graphAutocompleter}

--- a/src/ui/QueryEditor.tsx
+++ b/src/ui/QueryEditor.tsx
@@ -3,10 +3,10 @@ import { InlineFieldRow, VerticalGroup } from '@grafana/ui';
 import React from 'react';
 
 import { DataSource } from '../DataSource';
-import { RequestSpec } from '../RequestSpec';
+import { Aggregation, RequestSpec } from '../RequestSpec';
 import { CmkQuery, DataSourceOptions, GraphKind, ResponseDataAutocomplete } from '../types';
-import { titleCase, updateQuery } from '../utils';
-import { Presentation, createAutocompleteConfig } from './autocomplete';
+import { aggregationToPresentation, titleCase, updateQuery } from '../utils';
+import { createAutocompleteConfig } from './autocomplete';
 import {
   CheckMkSelect,
   CheckMkSelectNegatable,
@@ -49,7 +49,7 @@ export const QueryEditor = (props: Props): JSX.Element => {
   const { onChange, onRunQuery, datasource, query } = props;
   updateQuery(query);
   const rs = query.requestSpec || {};
-  const [qAggregation, setQAggregation] = React.useState(rs.aggregation || 'lines');
+  const [qAggregation, setQAggregation] = React.useState(rs.aggregation || 'off');
   const [qGraphType, setQGraphType] = React.useState(rs.graph_type || 'template');
   const [qSite, setQSite] = React.useState(rs.site);
   const [qHost, setQHost] = React.useState({
@@ -86,12 +86,12 @@ export const QueryEditor = (props: Props): JSX.Element => {
     onRunQuery();
   }
 
-  const presentationCompleter = async (): Promise<Array<SelectableValue<Presentation>>> => [
-    { value: 'lines', label: 'Lines' },
+  const aggregationCompleter = async (): Promise<Array<SelectableValue<Aggregation>>> => [
+    { value: 'off', label: 'Off' },
     { value: 'sum', label: 'Sum' },
     { value: 'average', label: 'Average' },
-    { value: 'min', label: 'Minimum' },
-    { value: 'max', label: 'Maximum' },
+    { value: 'minimum', label: 'Minimum' },
+    { value: 'maximum', label: 'Maximum' },
   ];
 
   const graphTypeCompleter = async (): Promise<Array<SelectableValue<GraphKind>>> => [
@@ -170,7 +170,7 @@ export const QueryEditor = (props: Props): JSX.Element => {
       } else {
         ident = 'combined_graphs';
         params = {
-          presentation: qAggregation, // TODO: not 100% sure if this is needed, but 2.0.1 does it that way
+          presentation: aggregationToPresentation(qAggregation), // TODO: not 100% sure if this is needed, but 2.0.1 does it that way
           mode: qGraphType,
           datasource: 'services',
           single_infos: ['host'],
@@ -292,7 +292,7 @@ export const QueryEditor = (props: Props): JSX.Element => {
           label={'Aggregation'}
           value={qAggregation}
           onChange={setQAggregation}
-          autocompleter={presentationCompleter}
+          autocompleter={aggregationCompleter}
         />
         <CheckMkSelect<'graph_type'>
           // TODO: duplicate with RAW edition!

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
 import { isUndefined } from 'lodash';
 
-import { NegatableOption, RequestSpec } from './RequestSpec';
+import { Aggregation, NegatableOption, RequestSpec } from './RequestSpec';
 import { CmkQuery } from './types';
+import { Presentation } from './ui/autocomplete';
 import { requestSpecFromLegacy } from './webapi';
 
 export const titleCase = (str: string): string => str[0].toUpperCase() + str.slice(1).toLowerCase();
@@ -76,4 +77,32 @@ export function updateQuery(query: CmkQuery): void {
     delete query.context;
     delete query.params;
   }
+}
+
+export function presentationToAggregation(presentation: Presentation): Aggregation {
+  let result: Aggregation = 'off';
+  if (presentation === 'lines') {
+    result = 'off';
+  } else if (presentation === 'min') {
+    result = 'minimum';
+  } else if (presentation === 'max') {
+    result = 'maximum';
+  } else {
+    result = presentation;
+  }
+  return result;
+}
+
+export function aggregationToPresentation(aggregation: Aggregation): Presentation {
+  let result: Presentation = 'lines';
+  if (aggregation === 'off') {
+    result = 'lines';
+  } else if (aggregation === 'minimum') {
+    result = 'min';
+  } else if (aggregation === 'maximum') {
+    result = 'max';
+  } else {
+    result = aggregation;
+  }
+  return result;
 }

--- a/src/webapi.ts
+++ b/src/webapi.ts
@@ -1,6 +1,6 @@
 import { NegatableOption, RequestSpec, TagValue } from './RequestSpec';
 import { Context, Edition, Params } from './types';
-import { createCmkContext } from './utils';
+import { aggregationToPresentation, createCmkContext, presentationToAggregation } from './utils';
 
 export interface WebAPiGetGraphResult {
   start_time: number;
@@ -80,7 +80,7 @@ export function requestSpecFromLegacy(context: Context, params: Params): Partial
   } else {
     rs.graph = params.graph_name; // TODO: make this happen!
   }
-  rs.aggregation = params.presentation;
+  rs.aggregation = presentationToAggregation(params.presentation);
   return rs;
 }
 
@@ -114,6 +114,11 @@ export function createWebApiRequestSpecification(
       graph_template = requestSpec.graph;
     }
   }
+
+  if (requestSpec.aggregation === undefined) {
+    throw new Error('web api: aggregation not defined!');
+  }
+
   return [
     'combined',
     {
@@ -121,7 +126,7 @@ export function createWebApiRequestSpecification(
       datasource: 'services',
       single_infos: ['host'],
       graph_template: graph_template,
-      presentation: requestSpec.aggregation,
+      presentation: aggregationToPresentation(requestSpec.aggregation),
     },
   ];
 }

--- a/tests/cypress/e2e/helpers.ts
+++ b/tests/cypress/e2e/helpers.ts
@@ -4,10 +4,10 @@ export const inputFilterSelector = 'input[id="react-select-7-input"]';
 export const inputGraphTypeSelector = 'input[id="input_Graph type"]';
 export const inputHostLabelsSelector = 'input[id="react-select-15-input"]';
 export const inputHostSelector = 'input[id="input_Hostname"]';
-export const inputMetricSelector = 'input[id="input_Metric"]';
+export const inputMetricSelector = 'input[id="input_Single metric"]';
 export const inputServiceSelector = 'input[id="input_Service"]';
 export const inputServiceRegexSelector = 'input[data-test-id="service_regex-filter-input"]';
-export const inputTemplateSelector = 'input[id="input_Template"]';
+export const inputTemplateSelector = 'input[id="input_Predefined graph"]';
 
 export function loginGrafana(grafanaUsername: string, passwordGrafana: string) {
   cy.visit('/login');

--- a/tests/unit/QueryEditor.test.tsx
+++ b/tests/unit/QueryEditor.test.tsx
@@ -107,16 +107,16 @@ describe('QueryEditor RAW', () => {
 
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        requestSpec: expect.objectContaining({ graph_type: 'metric' }),
+        requestSpec: expect.objectContaining({ graph_type: 'single_metric' }),
       })
     );
     expect(onRunQuery).toHaveBeenCalledTimes(1);
   });
 
   it.each`
-    graphType          | graphTypeTitle | selectChoice    | graphValue
-    ${'Template'}      | ${'Template'}  | ${'Graph One'}  | ${'graph_1'}
-    ${'Single metric'} | ${'Metric'}    | ${'Metric One'} | ${'metric_1'}
+    graphType             | graphTypeTitle        | selectChoice    | graphValue
+    ${'Predefined graph'} | ${'Predefined graph'} | ${'Graph One'}  | ${'graph_1'}
+    ${'Single metric'}    | ${'Single metric'}    | ${'Metric One'} | ${'metric_1'}
   `('selects the right graph', async ({ graphType, graphTypeTitle, selectChoice, graphValue }) => {
     render(<QueryEditor datasource={mockDatasource} query={query} onRunQuery={onRunQuery} onChange={onChange} />);
 
@@ -200,7 +200,7 @@ describe('QueryEditor RAW', () => {
     );
     autocompleterRequest.mockClear();
 
-    const graphInput = screen.getByLabelText('Template');
+    const graphInput = screen.getByLabelText('Predefined graph');
     await act(async () => {
       await selectEvent.select(graphInput, 'Graph One', { container: document.body });
     });

--- a/tests/unit/webapi.test.ts
+++ b/tests/unit/webapi.test.ts
@@ -4,7 +4,7 @@ import { createCmkContext } from '../../src/utils';
 import { requestSpecFromLegacy } from '../../src/webapi';
 
 const rs: RequestSpec = {
-  aggregation: 'lines',
+  aggregation: 'off',
   graph_type: 'metric',
   graph: 'ut_metric_id',
 
@@ -41,7 +41,7 @@ const params: Params = {
 };
 
 const rs_graph: Partial<RequestSpec> = {
-  aggregation: 'lines',
+  aggregation: 'off',
   graph_type: 'template',
   graph: 'cmk_cpu_time_by_phase',
 

--- a/tests/unit/webapi.test.ts
+++ b/tests/unit/webapi.test.ts
@@ -5,7 +5,7 @@ import { requestSpecFromLegacy } from '../../src/webapi';
 
 const rs: RequestSpec = {
   aggregation: 'off',
-  graph_type: 'metric',
+  graph_type: 'single_metric',
   graph: 'ut_metric_id',
 
   site: 'ut_site',
@@ -42,7 +42,7 @@ const params: Params = {
 
 const rs_graph: Partial<RequestSpec> = {
   aggregation: 'off',
-  graph_type: 'template',
+  graph_type: 'predefined_graph',
   graph: 'cmk_cpu_time_by_phase',
 
   site: 'cmk210dr',


### PR DESCRIPTION
By porting the graph endpoints from the WEB API to the REST API checkmk changed the name and type of presentation. WEB API used "lines, min, max,.."  REST API uses "off, minimum, maximum,...". As we still support the WEB API we have to keep both types and transform values between them.