### PR TITLE
Separate login from datasource creation

### DIFF
--- a/tests/cypress/e2e/helpers.ts
+++ b/tests/cypress/e2e/helpers.ts
@@ -24,14 +24,7 @@ export function addNewPanel() {
   cy.get('button[aria-label="Add new panel"]').click();
 }
 
-export function addCmkDatasource(
-  cmkUsername: string,
-  cmkPassword: string,
-  grafanaUsername: string,
-  passwordGrafana: string
-) {
-  loginGrafana(grafanaUsername, passwordGrafana);
-
+export function addCmkDatasource(cmkUsername: string, cmkPassword: string) {
   cy.visit('/datasources/new');
   cy.get('button[aria-label="Add data source Checkmk"]').contains('Checkmk').click();
 

--- a/tests/cypress/e2e/spec.cy.ts
+++ b/tests/cypress/e2e/spec.cy.ts
@@ -42,7 +42,8 @@ describe('e2e tests', () => {
     executeServiceDiscovery(hostName1, 'new');
     activateCmkChanges('cmk');
 
-    addCmkDatasource(cmkUser, cmkPassword, Cypress.env('grafanaUsername'), Cypress.env('grafanaPassword'));
+    loginGrafana(Cypress.env('grafanaUsername'), Cypress.env('grafanaPassword'));
+    addCmkDatasource(cmkUser, cmkPassword);
   });
 
   it('time-usage panel by service (single host)', {}, () => {


### PR DESCRIPTION
We here modify the datasource-creation function not to perform the login inside of it but rather in the tests' module.