### PR TITLE
(Do not merge) Remove plot-hovering assertion to avoid flaky behavior

### DIFF
--- a/tests/cypress/e2e/spec.cy.ts
+++ b/tests/cypress/e2e/spec.cy.ts
@@ -70,7 +70,6 @@ describe('e2e tests', () => {
     cy.assertLegendElement('Total execution time');
 
     cy.assertHoverSelectorsOff(4);
-    cy.assertHoverSelectorsOn(4);
   });
 
   it('time-usage panel by service (multiple hosts)', {}, () => {
@@ -94,7 +93,6 @@ describe('e2e tests', () => {
         cy.assertLegendElement('CPU time in operating system, ' + hostName1);
 
         cy.assertHoverSelectorsOff(8);
-        cy.assertHoverSelectorsOn(8);
 
         cy.get('[class="css-1a8393j-button"]').eq(3).click(); // Remove filter by service (TODO: introduce new button ID)
 
@@ -122,7 +120,6 @@ describe('e2e tests', () => {
     cy.assertLegendElement(hostName1);
 
     cy.assertHoverSelectorsOff(2);
-    cy.assertHoverSelectorsOn(2);
   });
 
   it('RAM-used panel by host labels (multiple hosts, single metric)', {}, () => {
@@ -146,7 +143,6 @@ describe('e2e tests', () => {
     cy.assertLegendElement(hostName1);
 
     cy.assertHoverSelectorsOff(2);
-    cy.assertHoverSelectorsOn(2);
   });
 
   it('RAM-used panel by service regex and hostname regex', {}, () => {
@@ -164,7 +160,6 @@ describe('e2e tests', () => {
     cy.assertLegendElement(hostName1);
 
     cy.assertHoverSelectorsOff(2);
-    cy.assertHoverSelectorsOn(2);
 
     cy.get(inputFilterSelector).type('Hostname regex{enter}'); // Filter -> 'Hostname regex'
     cy.contains('Hostname regex').should('exist');
@@ -176,7 +171,6 @@ describe('e2e tests', () => {
     cy.assertLegendElement('RAM used');
 
     cy.assertHoverSelectorsOff(1);
-    cy.assertHoverSelectorsOn(1);
 
     cy.get(inputHostRegexSelector).type('|' + hostName1 + '{enter}'); // Hostname regex -> '{hostname0}|{hostname1}'
     cy.get('input[value="' + hostName0 + '|' + hostName1 + '"]').should('exist');
@@ -186,7 +180,6 @@ describe('e2e tests', () => {
     cy.assertLegendElement(hostName1);
 
     cy.assertHoverSelectorsOff(2);
-    cy.assertHoverSelectorsOn(2);
   });
 
   it('Uptime panel by hostname', {}, () => {
@@ -209,6 +202,5 @@ describe('e2e tests', () => {
     cy.assertLegendElement('Uptime');
 
     cy.assertHoverSelectorsOff(1);
-    cy.assertHoverSelectorsOn(1);
   });
 });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -74,6 +74,9 @@ Cypress.Commands.add('assertHoverSelectorsOff', (nSelectors: number) => {
 });
 
 Cypress.Commands.add('assertHoverSelectorsOn', (nSelectors: number) => {
+  // such assertion leads to a flaky behavior inside the CI.
+  // TODO: assertion not used inside tests. Fix the flaky behavior or remove this custom command.
+
   // click on the panel (uncaught exception raised in the CI)
   cy.passOnException('ResizeObserver loop limit exceeded');
   cy.get(panelHoverSelector).click();


### PR DESCRIPTION
The plot-hovering process and assertion is currently leading to a flaky behavior in the CI. Such assertion is currently removed from the tests so that to have time to make such process more stable.