### PR TITLE
fix rrdtool create start argument

### DIFF
--- a/tests/checkmk-docker-hooks/post-start/generate_random_rrd_data.py
+++ b/tests/checkmk-docker-hooks/post-start/generate_random_rrd_data.py
@@ -58,7 +58,7 @@ def clone(original_rrd, clone_rrd):
     rrdtool.create(
         clone_rrd,
         "--start",
-        "0",
+        "20220101",
         "--step",
         "60",
         "--template",
@@ -77,7 +77,6 @@ def modify_in_place(filename):
     random.seed(filename)
 
     now = int(time.time())
-    print(now)
     randoms = [random_random_function() for _ in range(metrics_count)]
     for t in range(now - 5 * 60 * 60, now, 60):
         metrics = ":".join(str(r(t)) for r in randoms)


### PR DESCRIPTION
documentation for the `--start` argument says:
```
   Specifies the time in seconds since 1970-01-01 UTC when the first
   value should be added to the RRD
```

But this seems to be wrong. A 0 is interpreted as 00:00 because the input is tried to be parsed as "at-style". As we go back 5 hours, schedule the daily test-build around midnight, and rrd can not write data before `--start` the update fails.
The solution is to specify some random date in the past. I've choosen 2022-01-01