### PR TITLE
Expand existing CRE test to verify 'Service' input change

### DIFF
--- a/tests/cypress/e2e/spec.cy.ts
+++ b/tests/cypress/e2e/spec.cy.ts
@@ -264,6 +264,14 @@ describe('e2e tests', () => {
 
       cy.assertHoverSelectorsOff(4);
       cy.assertHoverSelectorsOn(4);
+
+      cy.contains("Could not find 'cmk_cpu_time_by_phase'").should('not.exist');
+
+      cy.inputLocatorById(inputServiceId).click(); // Service -> 'Memory'
+      cy.contains('Memory').click();
+      cy.contains('Memory').should('exist');
+
+      cy.contains("Could not find 'cmk_cpu_time_by_phase'").should('be.visible'); // Assert previous graph input not visible
     });
   });
 });


### PR DESCRIPTION
We here expand the existing CRE test to assert the absence of the previous 'Graph' input if the 'Service' input is modified.