### PR TITLE
Search for id in CheckMKAsyncSelect

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@
 
 const standard = require('@grafana/toolkit/src/config/jest.plugin.config');
 
-const extraTestPath = '**/tests/unit/*';
+const extraTestPath = '**/tests/unit/**/*';
 const config = standard.jestConfig();
 config.testMatch.push(extraTestPath);
 

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -54,4 +54,8 @@ export class DataSource extends DataSourceApi<CmkQuery> {
     }
     return this.restBackend;
   }
+
+  getUsername(): string {
+    return this.instanceSettings.jsonData.username!;
+  }
 }

--- a/src/RequestSpec.ts
+++ b/src/RequestSpec.ts
@@ -36,21 +36,14 @@ export type GraphType = 'single_metric' | 'predefined_graph';
 
 export type Aggregation = 'off' | 'sum' | 'average' | 'minimum' | 'maximum';
 
-export type RequestSpecStringKeys = 'host_name' | 'site' | 'service' | 'graph' | 'graph_type' | 'aggregation';
+export type PickByValue<T, V> = Pick<T, { [K in keyof T]: T[K] extends V ? K : never }[keyof T]>;
 
-export type RequestSpecNegatableOptionKeys = 'host_name_regex' | 'service_regex' | 'host_in_group' | 'service_in_group';
+export type RequestSpecStringKeys = keyof PickByValue<RequestSpec, string | undefined>;
+
+export type RequestSpecNegatableOptionKeys = keyof PickByValue<RequestSpec, NegatableOption | undefined>;
 
 export const defaultRequestSpec: Partial<RequestSpec> = {
   aggregation: 'off',
   graph_type: 'predefined_graph',
 };
-export type FilterEditorKeys =
-  | 'site'
-  | 'host_name'
-  | 'host_name_regex'
-  | 'host_in_group'
-  | 'host_labels'
-  | 'host_tags'
-  | 'service'
-  | 'service_regex'
-  | 'service_in_group';
+export type FilterEditorKeys = Exclude<keyof RequestSpec, 'graph_type' | 'aggregation' | 'graph'>;

--- a/src/backend/rest.ts
+++ b/src/backend/rest.ts
@@ -89,11 +89,22 @@ export default class RestApiBackend implements Backend {
         'The data source specified the Checkmk Enterprise Edition, but Checkmk Raw Edition was detected. Please choose the raw edition in the data source settings.'
       );
     }
+    // The REST API would be ok with other users, but the autocompleter are not
+    if (!(await this.isAutomationUser(this.datasource.getUsername()))) {
+      throw new Error('This data source must authenticate against Checkmk using an automation user.');
+    }
     return {
       status: 'success',
       message: `Data source is working, reached version ${checkMkVersion} of checkmk`,
       title: 'Success',
     };
+  }
+
+  async isAutomationUser(username: string): Promise<boolean> {
+    const response = await this.api<any>({
+      url: `/objects/user_config/${username}`,
+    });
+    return response.data['extensions']['auth_option']['auth_type'] === 'automation';
   }
 
   async api<T>(request: BackendSrvRequest): Promise<FetchResponse<T>> {

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -11,4 +11,6 @@ export interface DatasourceOptions {
   getBackend: () => Backend;
   getEdition: () => Edition;
   getUrl: () => string | undefined;
+
+  getUsername(): string;
 }

--- a/tests/unit/RequestSpec.test.ts
+++ b/tests/unit/RequestSpec.test.ts
@@ -1,0 +1,10 @@
+import { PickByValue } from '../../src/RequestSpec';
+
+type Test = PickByValue<{ foo: string; bar: number }, string>;
+const value: Test = { foo: '' };
+
+describe('we have no unit tests yet', () => {
+  it('but want just make sure PickByValue works as expected', () => {
+    expect(1).toStrictEqual(1);
+  });
+});

--- a/tests/unit/ui/CheckMkAsyncSelect.test.tsx
+++ b/tests/unit/ui/CheckMkAsyncSelect.test.tsx
@@ -1,0 +1,23 @@
+import { SelectableValue } from '@grafana/data';
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import { CheckMkAsyncSelect } from '../../../src/ui/components';
+
+describe('CheckMkAsyncSelect', () => {
+  const autocompleter = jest.fn(async (prefix: string): Promise<Array<SelectableValue<string>>> => {
+    if (prefix === 'sentinel') {
+      return [{ label: 'sentinel', value: 'sentinel' }];
+    }
+    return [];
+  });
+
+  it("uses the specific options if the default ones don't include the value", async () => {
+    const screen = await render(
+      <CheckMkAsyncSelect autocompleter={autocompleter} inputId={'foo'} onChange={() => undefined} value="sentinel" />
+    );
+
+    expect(autocompleter).toHaveBeenCalledWith('');
+    expect(autocompleter).toHaveBeenCalledWith('sentinel');
+  });
+});

--- a/tests/unit/ui/QueryEditor.test.tsx
+++ b/tests/unit/ui/QueryEditor.test.tsx
@@ -2,10 +2,10 @@ import { act, render, screen } from '@testing-library/react';
 import * as React from 'react';
 import selectEvent from 'react-select-event';
 
-import { DataSource } from '../../src/DataSource';
-import { defaultRequestSpec } from '../../src/RequestSpec';
-import { CmkQuery } from '../../src/types';
-import { QueryEditor } from '../../src/ui/QueryEditor';
+import { DataSource } from '../../../src/DataSource';
+import { defaultRequestSpec } from '../../../src/RequestSpec';
+import { CmkQuery } from '../../../src/types';
+import { QueryEditor } from '../../../src/ui/QueryEditor';
 
 const completions: Record<string, string[][]> = {
   sites: [


### PR DESCRIPTION
This MR is accompanied by a change in CheckMK that allows search the autocompleters by id.
It will be merged once that change is done.