### PR TITLE
Get rid of remaning eslint errors

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -94,6 +94,10 @@ export class DataSource extends DataSourceApi<CmkQuery> {
   }
 
   getUsername(): string {
-    return this.instanceSettings.jsonData.username!;
+    const username = this.instanceSettings.jsonData.username;
+    if (typeof username === 'string') {
+      return username;
+    }
+    throw Error('Impossible');
   }
 }

--- a/src/backend/rest.ts
+++ b/src/backend/rest.ts
@@ -101,7 +101,7 @@ export default class RestApiBackend implements Backend {
   }
 
   async isAutomationUser(username: string): Promise<boolean> {
-    const response = await this.api<any>({
+    const response = await this.api<{ extensions: { auth_option: { auth_type: string } } }>({
       url: `/objects/user_config/${username}`,
     });
     return response.data['extensions']['auth_option']['auth_type'] === 'automation';


### PR DESCRIPTION
Sadly there seems to be no feasable way for us to make all eslint warnings an error.