### PR TITLE
move error message rewrite to source of errors

### DIFF
--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -96,13 +96,7 @@ export const CheckMkGenericAsyncSelect = function <Value extends string | (strin
       } catch (e) {
         const error = e as Error;
         if (error && error.message) {
-          if (error.message === 'Sorry, you cannot create combined graphs for more than 100 objects') {
-            setAutocompleteError(
-              'Result size limit reached. Please add more filters to reduce the number of elements in the result.'
-            );
-          } else {
-            setAutocompleteError(error.message);
-          }
+          setAutocompleteError(error.message);
         }
         throw error;
       }


### PR DESCRIPTION
before "explore" and the graph panel did show the original (non rewritten) error message.

currently we have two problems with that implementation:
1. the error message is translated, so this only works in english instances of checkmk
2. we duplicated the code between rest and web api.

for 1. we plan to introduce a feature in the REST-API (but this will only solve the problem in `src/backend/rest.ts` not for the webapi!), we probably have to live with the code duplication.